### PR TITLE
yeilded user point plotting to the cursed edit toolbar

### DIFF
--- a/R/edit-data.R
+++ b/R/edit-data.R
@@ -32,6 +32,10 @@ add_point <- function(feature) {
 
 move_point <- function(feature, point_tbl) {
   id <- feature$properties$layerId
+  if (is.null(id)) {
+    id <- paste0("user", feature$properties[["_leaflet_id"]])
+  }
+  
   new_lon <- feature$geometry$coordinates[[1]]
   new_lat <- feature$geometry$coordinates[[2]]
   
@@ -57,6 +61,10 @@ move_point <- function(feature, point_tbl) {
 
 delete_point <- function(feature, point_tbl) {
   id <- feature$properties$layerId
+  
+  if (is.null(id)) {
+    id <- paste0("user", feature$properties[["_leaflet_id"]])
+  }
   
   point_tbl %>%
     mutate(


### PR DESCRIPTION
This took ages to come to a very unsatisfactory solution.

Things I found out you couldn't do:
* suppress any marker from being drawn by the `leaflet.extras::addDrawToolbar`
* delete the markers drawn by the toolbar
* add a `layerId` to markers drawn by the toolbar
* change the size of markers drawn by the toolbar

So I settled on drawing the markers with just the toolbar but using their position in the analysis. The points are bigger than the ones imported from CSV and GBIF but I think we'll just have to live with that.