### PR TITLE
Feature/message box for messages

### DIFF
--- a/R/app.R
+++ b/R/app.R
@@ -185,6 +185,9 @@ server <- function(input, output, session) {
       values$analysis_data <- bind_rows(values$analysis_data, valid_points)  
     }
     
+    msg <- glue::glue("Loaded {sum(valid_points$geocat_use)} points from a CSV")
+    values$messages <- c(values$messages, info_message(msg))
+    
     valid_points
   })
   
@@ -197,11 +200,19 @@ server <- function(input, output, session) {
     valid_points <- validated$valid_data
     values$analysis_data <- bind_rows(values$analysis_data, valid_points)
     
+    msg <- glue::glue("Loaded {nrow(valid_points)} points for <i>{input$gbif_name}</i> from GBIF")
+    values$messages <- c(values$messages, info_message(msg))
+    
     valid_points
   })
   
   powo_range <- shiny::eventReactive(input$powo_id, {
-    native_geom(input$powo_id)
+    geoms <- native_geom(input$powo_id)
+    
+    msg <- glue::glue("Loaded {nrow(geoms)} native regions from POWO for taxon {input$powo_id}")
+    values$messages <- c(values$messages, info_message(msg))
+      
+    geoms
   })
   
   output$messages <- renderPrint({
@@ -304,21 +315,29 @@ server <- function(input, output, session) {
   observeEvent(input$mymap_draw_new_feature, {
     point_data <- add_point(input$mymap_draw_new_feature)
     values$analysis_data <- bind_rows(values$analysis_data, point_data)
+    
+    msg <- format_new_point(input$mymap_draw_new_feature)
+    values$messages <- c(values$messages, info_message(msg))
   })
   
   #move points
   observeEvent(input$mymap_draw_edited_features, {
     for (feature in input$mymap_draw_edited_features$features){
-        values$analysis_data <- move_point(feature, values$analysis_data)
-      }
-    })
+      values$analysis_data <- move_point(feature, values$analysis_data)
+      
+      msg <- format_move_point(feature)
+      values$messages <- c(values$messages, info_message(msg))
+    }
+  })
 
   #delete points = actually just marks them not to display
   observeEvent(input$mymap_draw_deleted_features, {
     for (feature in input$mymap_draw_deleted_features$features){
       values$analysis_data <- delete_point(feature, values$analysis_data)
+      
+      msg <- format_delete_point(feature)
+      values$messages <- c(values$messages, info_message(msg))
     }
-    
   })
   
 ############################

--- a/R/app.R
+++ b/R/app.R
@@ -146,9 +146,12 @@ geocatApp <- function(...) {
   
   shiny::mainPanel(
     # map ----
-    leaflet::leafletOutput("mymap", width = "100%", height = 650)),
-    br(),
-    htmlOutput("messages")
+    div(
+      leaflet::leafletOutput("mymap", width = "100%", height = 550)),
+      br(),
+      wellPanel(htmlOutput("messages"),
+                style = "overflow-y: scroll; height: 100px; display: flex; flex-direction: column-reverse")
+    )
   )
 
 ##### server #####

--- a/R/edit-data.R
+++ b/R/edit-data.R
@@ -11,13 +11,7 @@
 #' 
 add_point <- function(feature) {
   id <- paste0("user", feature$properties[["_leaflet_id"]])
-  note <- paste0(
-    "New point added at (",
-    feature$geometry$coordinates[[1]],
-    ",",
-    feature$geometry$coordinates[[2]],
-    ")"
-  )
+  note <- format_new_point(feature)
   
   tibble::tibble(
     latitude=feature$geometry$coordinates[[2]],
@@ -40,16 +34,7 @@ move_point <- function(feature, point_tbl) {
   new_lat <- feature$geometry$coordinates[[2]]
   
   notes <- point_tbl[point_tbl$geocat_id == id,]$geocat_notes
-  notes <- paste0(
-    notes,
-    "> ",
-    "Point move to ",
-    "(",
-    new_lon,
-    ", ",
-    new_lat,
-    ")"
-  )
+  notes <- paste0(notes, "> ", format_move_point(feature))
     
   point_tbl %>%
     mutate(

--- a/R/import-data.R
+++ b/R/import-data.R
@@ -32,6 +32,7 @@ import_csv <- function(path) {
   data$geocat_source <- "User CSV"
   data$geocat_deleted <- FALSE
   data$geocat_id <- paste0("csv", seq(1, nrow(data)))
+  data$geocat_notes <- NA_character_
   
   data
 }
@@ -62,10 +63,15 @@ import_gbif <- function(name, limit=900) {
   }
   
   points <- gbif_points_(points)
+  if (nrow(points) == 0) {
+    return(empty_tbl_())
+  }
+  
   points$geocat_use <- TRUE
   points$geocat_deleted <- FALSE
   points$geocat_source <- "GBIF"
   points$geocat_id <- paste0("gbif", seq(1, nrow(points)))
+  points$geocat_notes <- NA_character_
   
   points
 }

--- a/R/messages.R
+++ b/R/messages.R
@@ -19,3 +19,21 @@ alert_message <- function(msg) {
 info_message <- function(msg) {
   message_(msg, "INFO", "#8ECAE6")
 }
+
+format_new_point <- function(feature) {
+  lat <- feature$geometry$coordinates[[1]]
+  lng <- feature$geometry$coordinates[[2]]
+  glue::glue("New point added at ({lat}, {lng})")
+}
+
+format_move_point <- function(feature) {
+  lat <- feature$geometry$coordinates[[1]]
+  lng <- feature$geometry$coordinates[[2]]
+  glue::glue("Point moved to ({lat}, {lng})")
+}
+
+format_delete_point <- function(feature) {
+  lat <- feature$geometry$coordinates[[1]]
+  lng <- feature$geometry$coordinates[[2]]
+  glue::glue("Point deleted from ({lat}, {lng})")
+}

--- a/R/messages.R
+++ b/R/messages.R
@@ -1,0 +1,17 @@
+# Functions to generate messages to the user
+
+error_message <- function(msg) {
+  glue::glue("<font color='#a9a9a9'><b>[ERROR]</b>: {msg}</font>")
+}
+
+warn_message <- function(msg) {
+  glue::glue("[WARNING]: {msg}")
+}
+
+alert_message <- function(msg) {
+  glue::glue("[ALERT]: {msg}")
+}
+
+info_message <- function(msg) {
+  glue::glue("[INFO]: {msg}")
+}

--- a/R/messages.R
+++ b/R/messages.R
@@ -1,17 +1,21 @@
 # Functions to generate messages to the user
 
+message_ <- function(msg, type, colour) {
+  glue::glue("<font color='{colour}'><b>[{type}]</b>: {msg}</font>")
+}
+
 error_message <- function(msg) {
-  glue::glue("<font color='#a9a9a9'><b>[ERROR]</b>: {msg}</font>")
+  message_(msg, "ERROR", "#B33A3A")
 }
 
 warn_message <- function(msg) {
-  glue::glue("[WARNING]: {msg}")
+  message_(msg, "WARNING", "#FF6700")
 }
 
 alert_message <- function(msg) {
-  glue::glue("[ALERT]: {msg}")
+  message_(msg, "ALERT", "#FFB703")
 }
 
 info_message <- function(msg) {
-  glue::glue("[INFO]: {msg}")
+  message_(msg, "INFO", "#8ECAE6")
 }

--- a/R/validate-data.R
+++ b/R/validate-data.R
@@ -17,24 +17,36 @@ validate_csv <- function(df) {
   validated <- mutate(
     df, 
     geocat_use=ifelse(is.na(longitude) | is.na(latitude), FALSE, geocat_use),
-    geocat_deleted=ifelse(is.na(longitude) | is.na(latitude), FALSE, geocat_deleted),
+    geocat_deleted=ifelse(is.na(longitude) | is.na(latitude), TRUE, geocat_deleted),
     geocat_notes=ifelse(is.na(longitude) | is.na(latitude), "Missing coordinates", geocat_notes)
   )
   
   msg <- c(msg, warn_message(check_range_(df, "longitude", -180, 180)))
   validated <- mutate(
-    df, 
-    geocat_use=ifelse(longitude < -180 | longitude > 180, FALSE, geocat_use),
-    geocat_deleted=ifelse(longitude < -180 | longitude > 180, FALSE, geocat_deleted),
-    geocat_notes=ifelse(longitude < -180 | longitude > 180, "Longitude out of range", geocat_notes)
-  )
+    validated, 
+    geocat_use=case_when(longitude < -180 ~ FALSE,
+                         longitude > 180 ~ FALSE, 
+                         TRUE ~ geocat_use),
+    geocat_deleted=case_when(longitude < -180 ~ TRUE,
+                             longitude > 180 ~ TRUE, 
+                             TRUE ~ geocat_deleted),
+    geocat_notes=case_when(longitude < -180 ~ "Longitude out of range",
+                           longitude > 180 ~ "Longitude out of range", 
+                           TRUE ~ geocat_notes)
+    )
   
   msg <- c(msg, check_range_(df, "latitude", -90, 90))
   validated <- mutate(
-    df, 
-    geocat_use=ifelse(latitude < -90 | latitude > 90, FALSE, geocat_use),
-    geocat_deleted=ifelse(latitude < -90 | latitude > 90, FALSE, geocat_deleted),
-    geocat_notes=ifelse(latitude < -90 | latitude > 90, "Latitude out of range", geocat_notes)
+    validated, 
+    geocat_use=case_when(latitude < -90 ~ FALSE,
+                         latitude > 90 ~ FALSE, 
+                         TRUE ~ geocat_use),
+    geocat_deleted=case_when(latitude < -90 ~ TRUE,
+                             latitude > 90 ~ TRUE, 
+                             TRUE ~ geocat_deleted),
+    geocat_notes=case_when(latitude < -90 ~ "Latitude out of range",
+                           latitude > 90 ~ "Latitude out of range", 
+                           TRUE ~ geocat_notes)
   )
   
   # alerts for dubious things


### PR DESCRIPTION
Added error/warning/alert/info messages in a box underneath the map. 
Messages are colour coded by type to highlight severity. I checked the colours for clashes for users with different types of colour blindness [using this tool](https://projects.susielu.com/viz-palette?colors=[%22#B33A3A%22,%22#FF6700%22,%22#FFB703%22,%22#8ECAE6%22]&backgroundColor=%22white%22&fontColor=%22black%22&mode=%22normal%22), and there were no significant clashes. Also, the type of message is included as part of the text, so can be understood without the colour.