### PR TITLE
Drop Shiny options for app launching

### DIFF
--- a/R/app.R
+++ b/R/app.R
@@ -1,6 +1,3 @@
-options(shiny.autoreload = TRUE)
-options(shiny.launch.browser = .rs.invokeShinyWindowExternal)
-
 #' @import shiny dplyr
 geocatApp <- function(...) {
   #### ui ####


### PR DESCRIPTION
These were added for development only and should have been removed.